### PR TITLE
README updates for QGIS server & Vs30map

### DIFF
--- a/mapbox/README.md
+++ b/mapbox/README.md
@@ -5,8 +5,7 @@ QGIS server allows a few other things such as retrieving the legend for the laye
 A `.qgs` project file contains a QGIS project which discribes layers and how they should be displayed.
 
 ## Installing QGIS server
-It seems the best version for Ubuntu/Debian is 3.10.14+dfsg-1 as the color bars are squashed in later versions and they tend to load tiles very slowly. 
-To install this specific version, 
+To install QGIS server, follow the steps below. 
 ```
 sudo mkdir -m755 -p /etc/apt/keyrings  # not needed since apt version 2.4.0 like Debian 12 and Ubuntu 22 or newer
 sudo wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
@@ -29,7 +28,9 @@ Then
 ```
 sudo apt update
 ```
-We are installing version 3.10.14 to avoid slow tile loading and squashed colorbar issue found in later versions (It seems version 3.18 and later, including the latest version 3.38 have these issues). To resolve dependency issues, install the following packages in order. 
+It seems the best version for Ubuntu/Debian is 3.10.14+dfsg-1. Version 3.18 and some newer versions (including latest version 3.38) were tested, but they have an issue with slow tile loading and squashed colorbar.
+
+To resolve dependency issues, install the following packages in order. 
 
 ```
 sudo apt install python3-qgis-common=3.10.14+dfsg-1 qgis-providers-common=3.10.14+dfsg-1

--- a/mapbox/README.md
+++ b/mapbox/README.md
@@ -74,74 +74,6 @@ If everything went well, it should have created a socket `/var/run/qgisserver.so
 
 
 
-## Updating QGS / Data
-You may need to update the project file when the data changes (eg: updated `.tif` dataset). This is because the colour scale may need to be adjusted for a new range.
-Open the project (vs30.qgs) on your computer, edit properties of the layer.
-<img width="510" alt="Screen Shot 2021-09-01 at 10 48 52 AM" src="https://user-images.githubusercontent.com/466989/131585718-4b27a6e0-364c-45bf-9d9c-ae01e809df43.png">
-
-QGIS is a little fiddly here. To make sure the min and max are updated, try some random values for min and max (eg.0 and 1000), select User defined, and click apply. Then change it to Min/max and apply again. This should find a new Min and Max values.
-<img width="1063" alt="Screen Shot 2021-09-01 at 10 18 22 AM" src="https://user-images.githubusercontent.com/466989/131585393-e94bddf7-87f4-41df-b209-9c138a5d350d.png">
-
-Click "Classify" and make sure the color scale now uses the new Min and Max values.
-
-<img width="869" alt="Screen Shot 2021-09-01 at 10 50 06 AM" src="https://user-images.githubusercontent.com/466989/131586674-3d00b6f9-01ed-44bd-a971-b2c2934fb69f.png">
-
-Also note that the number of steps in the colour scale or labels for each colour may have been customised so you will need to make those changes again.
-Save the file, and upload to /var/www/vs30map_data at Hypocentre (10.195.0.37), and restart the server.
-
-```
-sudo service qgis-server restart
-```
-
-Note that /etc/nginx/site-enabled/default has this entry
-
-```
-server {
-	listen 8008;
-	server_name hypocentre.canterbury.ac.nz;
-...
-
-	location /wms_vs30 {
-		gzip off;
-		include fastcgi_params;
-		fastcgi_param  QGIS_SERVER_LOG_STDERR  1;
-		fastcgi_param  QGIS_SERVER_LOG_LEVEL   0;
-		fastcgi_param  QGIS_PROJECT_FILE /var/www/vs30map_data/vs30.qgs;
-		fastcgi_pass unix:/var/run/qgisserver.socket;
-	}
-}
-
-```
-which can be controlled with `sudo service nginx {start|stop|restart|status}` command. Note that it uses `/var/run/qgisserver.socket`. 
-
-
-If something goes wrong, you can check the status by
-```
-sudo service qgis-server status
-```
-
-vs30.qgs may not be able to find the path to TIFF files. 
-
-```
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/combined_mvn.tif: No such fil>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/geology_mvn.tif: No such file>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/geology_mvn.tif: No such file>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/gid.tif: No such file or dire>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/slope.tif: No such file or di>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/terrain_mvn.tif: No such file>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/terrain_mvn.tif: No such file>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/tid.tif: No such file or dire>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/basins.tif: No such file or d>
-Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: More than 1000 errors or warnings have been reported. No mor>
-~
-```
-This happens because the QGIS software auto-finds the path to the local TIFF files and updates them, and the server can't find them.
-It's best to keep the vs30.qgs and all TIFF files in the same directory, and if needed, vs30.qgs can be edited and you can fix the path manually.
-```
-  <customproperties/>
-    <layer-tree-layer id="combined_mvn_da971f3a_6dc3_4e65_b7f5_e837a9e6040f" checked="Qt::Checked" source="./combined_mvn.tif" expanded="0" patch_size="-1,-1" legend_exp="" legend_split_behavior="0" name="Combined Vs30 (m/s)" providerKey="gdal">
-```
-
 ## QGIS Versions
 Up to version 3.16, gradient display in legends is unsupported.
 The docker image had version 3.16, you must edit the project in QGIS 3.16 or slightly older, opening the file in 3.18 will break the legends.
@@ -150,5 +82,5 @@ If the server is also updated, you may want to update the project to 3.18+ but m
 - JS client retrieving legend may want larger legend box to stretch the gradient rather than being just a short box (GET params).
 
 
-## Running QGIS Server
+## Serving Map data with QGIS Server
 Described in subfolders. 

--- a/mapbox/vs30/README.md
+++ b/mapbox/vs30/README.md
@@ -122,7 +122,8 @@ Go to `https://quakecoresoft.canterbury.ac.nz/vs30`. If you see this page, fanta
 
 
 ## Basin Data
-You need to generate a 100m grid data and which basin each grid point belongs to. Follow instructions in qgis/scripts/basin_z_values/readme.md
+You need to generate a 100m grid data and which basin each grid point belongs to. Follow instructions in [this page](https://github.com/uggmsim/mapping/mapbox/vs30/scripts/basin_z_values/readme.md) 
+
 
 Then update and run `basin2tif.py`. ￼
 

--- a/mapbox/vs30/README.md
+++ b/mapbox/vs30/README.md
@@ -94,7 +94,7 @@ It's best to keep the vs30.qgs and all TIFF files in the same directory, and if 
 
 ### Testing
 
-Test if this works by entering [http://hypocentre.canterbury.ac.nz:8008/wms_vs30](http://hypocentre.canterbury.ac.nz:8008/wms_vs30). If you see a page similar to this, it is all good.
+Test if this works by entering http://hypocentre.canterbury.ac.nz:8008/wms_vs30. If you see a page similar to this, it is all good.
 
 ![image](https://github.com/user-attachments/assets/5574aad4-1f5a-467a-9e2c-f83beb6a8842)
 
@@ -121,7 +121,7 @@ You need to restart NGINX server
 ```
 sudo systemctl restart nginx
 ```
-Go to [https://quakecoresoft.canterbury.ac.nz/vs30]. If you see this page, fantastic.
+Go to https://quakecoresoft.canterbury.ac.nz/vs30. If you see this page, fantastic.
 
 ![image](https://github.com/user-attachments/assets/42ab2c05-c5fe-47f0-84e5-d27d62b449e4)
 

--- a/mapbox/vs30/README.md
+++ b/mapbox/vs30/README.md
@@ -94,7 +94,7 @@ It's best to keep the vs30.qgs and all TIFF files in the same directory, and if 
 
 ### Testing
 
-Test if this works by entering `http://hypocentre.canterbury.ac.nz:8008/wms_vs30`. If you see a page similar to this, it is all good.
+Test if this works by entering [http://hypocentre.canterbury.ac.nz:8008/wms_vs30](http://hypocentre.canterbury.ac.nz:8008/wms_vs30). If you see a page similar to this, it is all good.
 
 ![image](https://github.com/user-attachments/assets/5574aad4-1f5a-467a-9e2c-f83beb6a8842)
 
@@ -121,7 +121,7 @@ You need to restart NGINX server
 ```
 sudo systemctl restart nginx
 ```
-Go to `https://quakecoresoft.canterbury.ac.nz/vs30`. If you see this page, fantastic.
+Go to [https://quakecoresoft.canterbury.ac.nz/vs30]. If you see this page, fantastic.
 
 ![image](https://github.com/user-attachments/assets/42ab2c05-c5fe-47f0-84e5-d27d62b449e4)
 

--- a/mapbox/vs30/README.md
+++ b/mapbox/vs30/README.md
@@ -53,12 +53,15 @@ server {
 
 ```
 which can be controlled with `sudo service nginx {start|stop|restart|status}` command. Note that it uses `/var/run/qgisserver.socket`. 
+
+### Firewall
 Note that we will be using port 8008, not the default 80. You might need to tell firewall to allow the traffic on the port.
 
 ```
 sudo ufw allow 8008
 ```
 
+### Troubleshooting
 
 If something goes wrong, you can check the status by
 ```
@@ -88,6 +91,8 @@ It's best to keep the vs30.qgs and all TIFF files in the same directory, and if 
   <customproperties/>
     <layer-tree-layer id="combined_mvn_da971f3a_6dc3_4e65_b7f5_e837a9e6040f" checked="Qt::Checked" source="./combined_mvn.tif" expanded="0" patch_size="-1,-1" legend_exp="" legend_split_behavior="0" name="Combined Vs30 (m/s)" providerKey="gdal">
 ```
+
+### Testing
 
 Test if this works by entering `http://hypocentre.canterbury.ac.nz:8008/wms_vs30`. If you see a page similar to this, it is all good.
 

--- a/mapbox/vs30/README.md
+++ b/mapbox/vs30/README.md
@@ -79,15 +79,17 @@ Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/tid
 Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: ERROR 4: /../../Vs30/vs30/data/basins.tif: No such file or d>
 Aug 31 18:10:25 UCRCC0304 spawn-fcgi[971561]: More than 1000 errors or warnings have been reported. No mor>
 ~
+
 ```
 This happens because the QGIS software auto-finds the path to the local TIFF files and updates them, and the server can't find them.
+
 It's best to keep the vs30.qgs and all TIFF files in the same directory, and if needed, vs30.qgs can be edited and you can fix the path manually.
 ```
   <customproperties/>
     <layer-tree-layer id="combined_mvn_da971f3a_6dc3_4e65_b7f5_e837a9e6040f" checked="Qt::Checked" source="./combined_mvn.tif" expanded="0" patch_size="-1,-1" legend_exp="" legend_split_behavior="0" name="Combined Vs30 (m/s)" providerKey="gdal">
-```**
+```
 
-Test if this works by entering `http://hypocentre.canterbury.ac.nz:8008/wms_vs30`
+Test if this works by entering `http://hypocentre.canterbury.ac.nz:8008/wms_vs30`. If you see a page similar to this, it is all good.
 
 ![image](https://github.com/user-attachments/assets/5574aad4-1f5a-467a-9e2c-f83beb6a8842)
 
@@ -114,9 +116,13 @@ You need to restart NGINX server
 ```
 sudo systemctl restart nginx
 ```
+Go to `https://quakecoresoft.canterbury.ac.nz/vs30`. If you see this page, fantastic.
+
+![image](https://github.com/user-attachments/assets/42ab2c05-c5fe-47f0-84e5-d27d62b449e4)
+
 
 ## Basin Data
-You need to generate a 100m grid data and which basin each grid point belongs to (A sample basin_stats_z.csv can be obtained from  [Dropbox link](https://www.dropbox.com/scl/fi/95q6ysyv3arq7hbdkl6ze/basin_stats_z.csv?rlkey=0extrc3rn0am2jq2e7bjfogrv&dl=0) ). For a fresh generation, follow instructions in qgis/scripts/basin_z_values/readme.md
+You need to generate a 100m grid data and which basin each grid point belongs to. Follow instructions in qgis/scripts/basin_z_values/readme.md
 
 Then update and run `basin2tif.py`. ￼
 
@@ -128,14 +134,14 @@ After that, update `map.js` and add new basin names
 
 ![Screen Shot 2021-09-01 at 11 16 27 AM](https://user-images.githubusercontent.com/466989/131588093-80383082-5675-48fc-92f9-af37dfbfef66.png)
 
-Note that map.js alongside index.html are hosted on /var/www/Vs30 @ ucquakecore1p server
+Note that map.js alongside index.html are hosted on /var/www/Vs30 @ ucquakecore2p server
 
-### Steps.
+### Summary of Steps.
 1. Run basin2tif.py and produce basins.tif. 
 2. Copy this to where vs30.qgs is located. Open vs30.qgs with QGIS. Make it find basins.tif at ./basins.tif
 3. Update color scale for each property.
 4. Save vs30.qgs
-5. Copy vs30.qgs and basins.tif to /data/vs30/ @ RCC
-6. Copy map.js to /var/www/Vs30 @ ucquakecore1p
-7. Restart qgis server
+5. Copy vs30.qgs and basins.tif to /var/www/vs30map_data @ Hypocentre
+6. Copy map.js to /var/www/Vs30 @ ucquakecore2p (it might have updates to `NAME_BASIN` list)
+7. Restart qgis server at Hypoctnre.
 8. Check the service status - if .tif files are not found, edit vs30.qgs with an editor and fix the paths.

--- a/mapbox/vs30/README.md
+++ b/mapbox/vs30/README.md
@@ -149,5 +149,5 @@ Note that map.js alongside index.html are hosted on /var/www/Vs30 @ ucquakecore2
 4. Save vs30.qgs
 5. Copy vs30.qgs and basins.tif to /var/www/vs30map_data @ Hypocentre
 6. Copy map.js to /var/www/Vs30 @ ucquakecore2p (it might have updates to `NAME_BASIN` list)
-7. Restart qgis server at Hypoctnre.
+7. Restart qgis server at Hypocentre.
 8. Check the service status - if .tif files are not found, edit vs30.qgs with an editor and fix the paths.

--- a/mapbox/vs30/README.md
+++ b/mapbox/vs30/README.md
@@ -13,7 +13,7 @@ You may need to update the project file when the data changes (eg: updated `.tif
 Open the project (vs30.qgs) on your computer, edit properties of the layer.
 <img width="510" alt="Screen Shot 2021-09-01 at 10 48 52 AM" src="https://user-images.githubusercontent.com/466989/131585718-4b27a6e0-364c-45bf-9d9c-ae01e809df43.png">
 
-QGIS is a little fiddly here. To make sure the min and max are updated, try some random values for min and max (eg.0 and 1000), select User defined, and click apply. Then change it to Min/max and apply again. This should find a new Min and Max values.
+QGIS is a little fiddly here. To make sure the min and max are updated, try some random values for min and max (e.g. 0 and 1000), select User defined, and click apply. Then change it to Min/max and apply again. This should find a new Min and Max values.
 <img width="1063" alt="Screen Shot 2021-09-01 at 10 18 22 AM" src="https://user-images.githubusercontent.com/466989/131585393-e94bddf7-87f4-41df-b209-9c138a5d350d.png">
 
 Click "Classify" and make sure the color scale now uses the new Min and Max values.


### PR DESCRIPTION
Revised READMEs to incorporate the changes due to migration out of RCC VM.
QGIS server is now running on Hypocentre and the static portion of Vs30 map remains to be hosted on ucquakecore2p.